### PR TITLE
refactor: improve performance of /mappings/dict endpoint

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -145,7 +145,7 @@ async def create_concept(id: str, concept_name: str, terminology_name: str):
 
 @app.get("/mappings", tags=["mappings"])
 async def get_all_mappings():
-    mappings = repository.get_all_mappings()
+    mappings = repository.get_mappings()
     return mappings
 
 
@@ -249,16 +249,16 @@ async def get_closest_mappings_for_dictionary(
         df = data_dict_source.to_dataframe()
 
         # Collect descriptions and their corresponding variables
-        descriptions = df[description_field].to_list()
-        variables = df[variable_field].to_list()
+        descriptions = df["description"].to_list()
+        variables = df["variable"].to_list()
 
         # Generate embeddings for all descriptions in batches
         embeddings = embedding_model.get_embeddings(descriptions)
 
-        # Process embeddings to get closes mappings
+        # Process embeddings to get closest mappings
         response = []
         for variable, description, embedding in zip(variables, descriptions, embeddings):
-            closest_mappings = repository.get_terminology_and_model_specific_closest_mappings(
+            closest_mappings = repository.get_terminology_and_model_specific_closest_mappings_with_similarities(
                 embedding, terminology_name, model, limit=limit
             )
             mappings_list = [


### PR DESCRIPTION
1. Moved `MPNetAdapter` Initialization Outside the Loop:

    - Previously, the `MPNetAdapter` instance was being created inside the loop, causing redundant initializations and significantly impacting performance. The instance is now initialized once before the loop, improving efficiency.

2. Batch Embedding Generation:

    - Embeddings were being generated one-by-one for each description during iteration over rows, leading to unnecessary computation overhead.
    - Replaced this with batch embedding generation using the `get_embeddings()` method, which computes embeddings for all descriptions before entering the loop.

3. Exposed `limit` Parameter in the Endpoint:

    - The `limit` parameter in the `get_embeddings()` function, which restricts the number of closest matches for a description, was previously hardcoded to 5.
    - Added the `limit` parameter to the endpoint, allowing users to configure it dynamically.

4. File Parameter Validation:

    - Previously, there was no validation to ensure that the file parameter was passed correctly.
    - Added validation to check if a file is provided and whether it has a valid extension, improving error handling and preventing unexpected failures.

closes #75 